### PR TITLE
Add a more permissive dependency to jquery

### DIFF
--- a/package.js
+++ b/package.js
@@ -21,7 +21,7 @@ Package.onUse(function(api) {
     'blaze@2.5.0',
     'reactive-dict',
     'templating@1.4.1',
-    'jquery@3.0.0'
+    'jquery@1.11.9||3.0.0'
   ], 'client');
 
   api.use([


### PR DESCRIPTION
This commit is made in order to avoid conflicts with other packages that have lower dependency to jquery

Here is an example :
```
While selecting package versions:
   error: Conflict: Constraint jquery@3.0.0 is not satisfied by jquery 1.11.3.
   Constraints on package "jquery":
   * jquery@1.11.9 || 3.0.0 <- blaze 2.5.0 <- alanning:roles 3.3.0
   * jquery@3.0.0 <- useraccounts:core 1.15.1 <- mealsunite:flow-routing-extra 2.0.2
   * jquery@1.0.1 <- kadira:blaze-layout 2.3.0
   * jquery@1.0.0 <- percolate:momentum 0.7.2
   * jquery@1.0.0 <- natestrauser:select2 4.0.3
   * jquery@1.0.0 <- zuuk:stale-session 1.0.3
   * jquery@1.0.1 <- froala:editor 2.8.5
   * jquery@1.11.3 <- deanius:promise 1.0.3
   * jquery@1.11.4 <- msavin:mongol 7.0.1
   * jquery@1.11.4 <- meteortoys:toykit 4.0.2 <- msavin:mongol 7.0.1
```