### PR TITLE
Update the dependency to softwarerero:meteor-accounts-t9n for the npm…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.npm
 .build*
 versions.json

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 This repository provides versions for the package [useraccounts:core](https://github.com/meteor-compat/useraccounts-core/) that are compatible with latest Meteor. This is necessary because the author is not maintaining package anymore.
 
 ## Changes
+
+- v1.15.1
+  - [T9n](https://github.com/softwarerero/meteor-accounts-t9n) was updated to the last version which is an NPM package (because of low coffeescript dependency in previous version). `T9n` object is exposed globally to the app after adding `useraccounts:core`. If you need to add more languages, you need to add the npm package to your app `meteor npm install --save meteor-accounts-t9n` to be able to require the language file and set it up :
+  ```javascript
+  T9n.map('fr', require('meteor-accounts-t9n/build/fr'));
+  ```
+  
+
 - v1.15.0
   - `api.versionsFrom` on `Package.onUse` was changed from `1.0.3` to `2.4` to avoid errors like:
       ```txt

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository provides versions for the package [useraccounts:core](https://gi
 
 ## Changes
 
-- v1.15.1
+- v1.16.0
   - [T9n](https://github.com/softwarerero/meteor-accounts-t9n) was updated to the last version which is an NPM package (because of low coffeescript dependency in previous version). `T9n` object is exposed globally to the app after adding `useraccounts:core`. If you need to add more languages, you need to add the npm package to your app `meteor npm install --save meteor-accounts-t9n` to be able to require the language file and set it up :
   ```javascript
   T9n.map('fr', require('meteor-accounts-t9n/build/fr'));

--- a/lib/T9n.js
+++ b/lib/T9n.js
@@ -1,0 +1,5 @@
+T9n = require('meteor-accounts-t9n').T9n;
+import {en} from 'meteor-accounts-t9n/build/en';
+
+T9n.map("en", en);
+T9n.setLanguage('en');

--- a/package.js
+++ b/package.js
@@ -2,9 +2,13 @@
 
 Package.describe({
   summary: 'Meteor sign up and sign in templates core package.',
-  version: '1.15.0',
+  version: '1.15.1',
   name: 'useraccounts:core',
   git: 'https://github.com/meteor-compat/useraccounts-core',
+});
+
+Npm.depends({
+  "meteor-accounts-t9n": "2.6.0",
 });
 
 Package.onUse(function(api) {
@@ -15,6 +19,7 @@ Package.onUse(function(api) {
     'check',
     'underscore',
     'reactive-var',
+    'ecmascript',
   ], ['client', 'server']);
 
   api.use([
@@ -30,7 +35,6 @@ Package.onUse(function(api) {
 
   api.imply([
     'accounts-base',
-    'softwarerero:accounts-t9n@1.3.3',
   ], ['client', 'server']);
 
   api.imply([
@@ -43,6 +47,7 @@ Package.onUse(function(api) {
     'lib/server.js',
     'lib/methods.js',
     'lib/server_methods.js',
+    'lib/T9n.js',
   ], ['server']);
 
   api.addFiles([
@@ -71,10 +76,11 @@ Package.onUse(function(api) {
     'lib/templates_helpers/ensure_signed_in.html',
     'lib/templates_helpers/ensure_signed_in.js',
     'lib/methods.js',
+    'lib/T9n.js',
   ], ['client']);
 
   api.export([
-    'AccountsTemplates',
+    'AccountsTemplates', 'T9n'
   ], ['client', 'server']);
 });
 

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 
 Package.describe({
   summary: 'Meteor sign up and sign in templates core package.',
-  version: '1.15.1',
+  version: '1.16.0',
   name: 'useraccounts:core',
   git: 'https://github.com/meteor-compat/useraccounts-core',
 });


### PR DESCRIPTION
Following this [discussion](https://github.com/meteor/meteor/discussions/11743), a new proposition for the update of dependency, with a version bump 

This PR adds the npm package `meteor-accounts-t9n` as a dependency and expose globally the T9n object (which was the previous default behavior of T9n and remove the need to npm install `meteor-accounts-t9n` into the project )