### PR TITLE
Fix T9n initialization issue

### DIFF
--- a/lib/T9n.js
+++ b/lib/T9n.js
@@ -1,5 +1,5 @@
 T9n = require('meteor-accounts-t9n').T9n;
-import {en} from 'meteor-accounts-t9n/build/en';
+import en from 'meteor-accounts-t9n/build/en';
 
 T9n.map("en", en);
 T9n.setLanguage('en');


### PR DESCRIPTION
This fixes the issue with wrong form labels rendered which is caused by incorrect importing of T9n string assets file.

**Reproduction repository** is available [here](https://github.com/imajus/meteor-test-useraccounts-t9n).
**Run as**: `meteor npm start` and then open [http://localhost:3000](http://localhost:3000) in the browser.
**Expected behaviour**: `useraccounts:unstyled` form is rendered with proper form input labels e.g. "Email", "Password", "Don't have an account?", etc.
**Actual behaviour**: Some of the form input labels aren't rendered properly, e.g. "password" instead of "Password", "dontHaveAnAccount" instead of "Don't have an account?".