### PR TITLE
Fix username login when using 'username_and_email' field

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -123,10 +123,10 @@ AT.prototype._init = function() {
       }
 
       var ok = true;
-      var loginEmail = attempt.methodArguments[0].user.email.toLowerCase();
+      var loginEmail = attempt.methodArguments[0].user.email;
       if (loginEmail) {
         var email = _.filter(user.emails, function(obj) {
-          return obj.address.toLowerCase() === loginEmail;
+          return obj.address.toLowerCase() === loginEmail.toLowerCase();
         });
         if (!email.length || !email[0].verified) {
           ok = false;


### PR DESCRIPTION
Fixed the Bug reported in this [Issue](https://github.com/meteor-compat/useraccounts-core/issues/4).

When using the field 'username_and_email' to login, only the email is working.

In line 126 `attempt.methodArguments[0].user.email` is undefined when logging in only with an username.

Therefore `toLowerCase()` hast to be called inside the email-branch, to prevent an `Cannot read property 'toLowerCase' of undefined` Error.