### PR TITLE
Fixed a bug with const declaration instead let

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -536,7 +536,7 @@ AT.prototype.getRoutePath = function(route) {
 
 AT.prototype.oauthServicesHelper = function(serviceNames, configuredServices) {
   // Builds a list of objects containing service name as _id and its configuration status
-  const services = _.map(serviceNames, function(name) {
+  let services = _.map(serviceNames, function(name) {
     return {
       _id : name,
       configured: _.contains(configuredServices, name),

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 
 Package.describe({
   summary: 'Meteor sign up and sign in templates core package.',
-  version: '1.17.1',
+  version: '1.17.2',
   name: 'useraccounts:core',
   git: 'https://github.com/meteor-compat/useraccounts-core',
 });


### PR DESCRIPTION
In the file `lib/core.js` a variable was defined as a constant, but it is reassigned a couple of line below, then it was necessary change it in with `let` definition. 