### PR TITLE
Update const to let that is written to!

### DIFF
--- a/lib/templates_helpers/at_pwd_form.js
+++ b/lib/templates_helpers/at_pwd_form.js
@@ -99,12 +99,12 @@ AT.prototype.atPwdFormEvents = {
         }
 
         // Extracts username, email, and pwds
-        const current_password = formData.current_password;
-        const email = formData.email;
-        const password = formData.password;
-        const password_again = formData.password_again;
-        const username = formData.username;
-        const username_and_email = formData.username_and_email;
+        let current_password = formData.current_password;
+        let email = formData.email;
+        let password = formData.password;
+        let password_again = formData.password_again;
+        let username = formData.username;
+        let username_and_email = formData.username_and_email;
         // Clears profile data removing username, email, and pwd
         delete formData.current_password;
         delete formData.email;


### PR DESCRIPTION
We just found out the hard way that we have people who use email / password on our service after updating to meteor 3. We show case apple and google login, but have a "fallback" option to allow someone to use an email / password. After pushing out an update we quickly realized users were having issues & that we need to update / run our workflow tests for logging in with email :)

<img width="630" alt="Screenshot 2025-03-17 at 6 12 18 AM" src="https://github.com/user-attachments/assets/a29d6599-bd7c-45bd-90cb-4f344c19884f" />
